### PR TITLE
feat: add missing View ref methods to BaseKeyboardView ref

### DIFF
--- a/src/components/BaseKeyboardView/BaseKeyboardView.tsx
+++ b/src/components/BaseKeyboardView/BaseKeyboardView.tsx
@@ -49,6 +49,21 @@ export const BaseKeyboardView = React.memo(
             Commands.focus(targetRef.current as NativeRef);
           }
         },
+        blur: () => {
+          targetRef.current?.blur();
+        },
+        measure: (...args: Parameters<View['measure']>) => {
+          targetRef.current?.measure(...args);
+        },
+        measureInWindow: (...args: Parameters<View['measureInWindow']>) => {
+          targetRef.current?.measureInWindow(...args);
+        },
+        measureLayout: (...args: Parameters<View['measureLayout']>) => {
+          targetRef.current?.measureLayout(...args);
+        },
+        setNativeProps: (...args: Parameters<View['setNativeProps']>) => {
+          targetRef.current?.setNativeProps(...args);
+        },
       }));
 
       const bubbled = useBubbledInfo(onBubbledContextMenuPress);


### PR DESCRIPTION
Hi @ArturKalach 

This PR is just a suggestion. 
When I implemented the keyboard Pressable across my codebase I had to use 2 refs, one for the viewRef and other for the keyboardViewRef which have the focus method.

But to avoid refactoring many of my components to use the viewRef instead of ref, I opted for patching the `react-native-external-keyboard` package with the changes present on this PR.

I'm not sure if only having the focus method is a design choice, but for me it makes sense having the other methods present on a View ref.

Let me know what you think.