### PR TITLE
feat: add `AccessibilityInfo.setAccessibilityFocus` to BaseKeyboardView ref focus method

### DIFF
--- a/src/components/BaseKeyboardView/BaseKeyboardView.tsx
+++ b/src/components/BaseKeyboardView/BaseKeyboardView.tsx
@@ -1,5 +1,5 @@
 import React, { type ComponentType, useImperativeHandle, useRef } from 'react';
-import { Platform } from 'react-native';
+import { Platform, AccessibilityInfo, findNodeHandle } from 'react-native';
 import { ExternalKeyboardViewNative } from '../../nativeSpec';
 import { Commands } from '../../nativeSpec/ExternalKeyboardViewNativeComponent';
 import type {
@@ -47,6 +47,10 @@ export const BaseKeyboardView = React.memo(
         focus: () => {
           if (targetRef?.current) {
             Commands.focus(targetRef.current as NativeRef);
+            const reactTag = findNodeHandle(targetRef.current);
+            if (reactTag) {
+              AccessibilityInfo.setAccessibilityFocus(reactTag);
+            }
           }
         },
       }));


### PR DESCRIPTION
Hey @ArturKalach 

Another opinionated PR.

Across my codebase I have to use the `AccessibilityInfo.setAccessibilityFocus` to set where I want TalkBack/VoiceOver to focus. Now with the keyboard support I also have to do it with the keyboard ref.

For now I've patched it locally to do the accessibility focus on the BaseKeyboardView focus method. But I also understand that it's not the responsibility of this library to deal with accessibility focus.

What do you think?