### PR TITLE
fix(android): Add missing getDelegate() for New Architecture ViewManagers

### DIFF
--- a/android/src/newarch/ExternalKeyboardViewManagerSpec.java
+++ b/android/src/newarch/ExternalKeyboardViewManagerSpec.java
@@ -1,8 +1,23 @@
 package com.externalkeyboard;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.viewmanagers.ExternalKeyboardViewManagerInterface;
+import com.facebook.react.viewmanagers.ExternalKeyboardViewManagerDelegate;
+import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewManager;
 
 public abstract class ExternalKeyboardViewManagerSpec<T extends ReactViewGroup> extends ReactViewManager implements ExternalKeyboardViewManagerInterface<T> {
+  private final ViewManagerDelegate<T> mDelegate;
+
+  public ExternalKeyboardViewManagerSpec() {
+    mDelegate = new ExternalKeyboardViewManagerDelegate(this);
+  }
+
+  @Nullable
+  @Override
+  protected ViewManagerDelegate<T> getDelegate() {
+    return mDelegate;
+  }
 }

--- a/android/src/newarch/KeyboardFocusGroupManagerSpec.java
+++ b/android/src/newarch/KeyboardFocusGroupManagerSpec.java
@@ -1,8 +1,23 @@
 package com.externalkeyboard;
 
+import androidx.annotation.Nullable;
+
 import com.facebook.react.viewmanagers.KeyboardFocusGroupManagerInterface;
+import com.facebook.react.viewmanagers.KeyboardFocusGroupManagerDelegate;
+import com.facebook.react.uimanager.ViewManagerDelegate;
 import com.facebook.react.views.view.ReactViewGroup;
 import com.facebook.react.views.view.ReactViewManager;
 
 public abstract class KeyboardFocusGroupManagerSpec<T extends ReactViewGroup> extends ReactViewManager implements KeyboardFocusGroupManagerInterface<T> {
+  private final ViewManagerDelegate<T> mDelegate;
+
+  public KeyboardFocusGroupManagerSpec() {
+    mDelegate = new KeyboardFocusGroupManagerDelegate(this);
+  }
+
+  @Nullable
+  @Override
+  protected ViewManagerDelegate<T> getDelegate() {
+    return mDelegate;
+  }
 }


### PR DESCRIPTION
 ## Problem

  When using the New Architecture (Fabric) on Android, the app crashes on some devices on startup:

  ViewManager using codegen must override getDelegate method (name: ExternalKeyboardView)

  ## Root Cause

  In `android/src/newarch/`, two ViewManager specs implement Codegen interfaces but don't provide the required `getDelegate()` method:

  - `ExternalKeyboardViewManagerSpec.java`
  - `KeyboardFocusGroupManagerSpec.java`

  Note: `TextInputFocusWrapperManagerSpec.java` already has the correct implementation.

  ## Solution

  Added delegate initialization and `getDelegate()` override to both specs, matching the existing pattern in `TextInputFocusWrapperManagerSpec.java`.

  ## Related

  - React Native Fabric Native Components: https://reactnative.dev/docs/fabric-native-components-introduction
  - ViewManagerDelegate discussion: https://github.com/reactwg/react-native-new-architecture/discussions/141
